### PR TITLE
handle problematic stream files

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ Miscellaneous functions for aiding calibration during SFX experiments at LCLS.
 ## Contributing
 This repository is the centralized location to discuss and share calibration files, documentation, scripts and code for SFX analysis.
 
-See "Discussions" above for a forum experience.
-Contribute or check "Wiki" above for tutorials and tips, shared experience, etc.
+See [Discussions](https://github.com/apeck12/sfx_utils/discussions) above for a forum experience.
+Contribute or check [Wiki](https://github.com/apeck12/sfx_utils/wiki) above for tutorials and tips, shared experience, etc.
 
 For contributing code and script, please don't push to the main branch directly. Rather, work in a specific branch for the task at hand, and make a pull request (PR) so it can be safely merged into the main branch after the person you assign as a reviewer does the code review (if necessary).
 


### PR DESCRIPTION
(Description copied from https://github.com/apeck12/sfx_utils/pull/16.)

We encountered a problematic stream file in which the information for a subset of chunks was cut off, e.g.:
```
$ sed '16467210,16493293!d' r0029.stream  
-15   18   21      24.21     229.14     528.29     347.06  206.5 1174.8 p2a0
 -15   19   21    1316.01     236.----- Begin chunk -----
Image filename: /cds/data/drpsrcf/cxi/cxilz0720/scratch/cheetah/hdf5/r0029-sab1/cxilz0720-r0029_6.cxi
...
```
which caused problems during stream reading, since an "End of reflections" line at the end of the chunk was expected. The `read_stream` function has been modified such that these problematic lines will be interpreted as the end of a chunk. A warning will be printed out for each partial chunk encountered, but valid reflections prior to and following this problematic line will be included in the `stream_data` class variable. (Despite these seemingly problematic chunks, the remainder of the data from this stream file looks fine.)

This fix resolves issue #8.