### PR TITLE
handling case of an unindexed stream

### DIFF
--- a/sfx_utils/stream_interface.py
+++ b/sfx_utils/stream_interface.py
@@ -67,7 +67,10 @@ class StreamInterface:
 
         stream_data = np.array(stream_data)
         if not self.cell_only:
-            stream_data[:,-1] = xtal_utils.compute_resolution(stream_data[:,2:8], stream_data[:,8:11])
+            if len(stream_data) == 0:
+                print("Warning: no indexed reflections found!")
+            else:
+                stream_data[:,-1] = xtal_utils.compute_resolution(stream_data[:,2:8], stream_data[:,8:11])
                 
         return stream_data
     


### PR DESCRIPTION
This change results in a warning rather than error being returned by the `StreamInterface` class in case a stream file is loaded that contains only unindexed reflections, in which case neither the peakogram nor unit cell distributions can be plotted. This change addresses Issue #10.