### PR TITLE
fixing swapped max and peak intensity variables

### DIFF
--- a/sfx_utils/stream_interface.py
+++ b/sfx_utils/stream_interface.py
@@ -90,23 +90,23 @@ class StreamInterface:
         if self.cell_only:
             print("Reflections were not extracted")
         else:
-            return self.stream_data[:,-3]
+            return self.stream_data[:,-5]
 
     def get_peak_maxI(self):
         """ Retrieve max intensity of peaks from self.stream_data. """
         if self.cell_only:
             print("Reflections were not extracted")
         else:
-            return self.stream_data[:,-5]
+            return self.stream_data[:,-3]
     
     def get_peak_sigI(self):
-        """ Retrieve max intensity of peaks from self.stream_data. """
+        """ Retrieve peaks' standard deviations from self.stream_data. """
         if self.cell_only:
             print("Reflections were not extracted")
         else:
             return self.stream_data[:,-4]
     
-    def plot_peakogram(self, output=None):
+    def plot_peakogram(self, output=None, plot_Iogram=False):
         """
         Generate a peakogram of the stream data.
         
@@ -114,15 +114,24 @@ class StreamInterface:
         ----------
         output : string, default=None
             if supplied, path for saving png of peakogram
+        plot_Iogram : boolean, default=False
+            if True, plot integrated rather than max intensities in the peakogram
         """
         if self.cell_only:
             print("Cannot plot peakogram because only cell parameters were extracted")
             return
               
         peak_res = self.get_peak_res()
-        peak_sum = self.get_peak_sumI()
-        peak_max = self.get_peak_maxI()
         peak_sig = self.get_peak_sigI()
+        if not plot_Iogram:
+            peak_sum = self.get_peak_sumI()
+            peak_max = self.get_peak_maxI()
+            xlabel, ylabel = "sum", "max"
+        # if Iogram, swap peak_sum and peak_max
+        else:
+            peak_sum = self.get_peak_maxI()
+            peak_max = self.get_peak_sumI()
+            xlabel, ylabel = "max", "sum"
 
         figsize = 8
         peakogram_bins = [500, 500]
@@ -139,14 +148,14 @@ class StreamInterface:
         im = ax1.pcolormesh(yedges, xedges, H, cmap='gray', norm=LogNorm())
         plt.colorbar(im)
         ax1.set_xlabel("1/d (${\mathrm{\AA}}$$^{-1}$)")
-        ax1.set_ylabel("log(peak intensity)")
+        ax1.set_ylabel(f"log(peak intensity) - {ylabel}")
 
         irow += 1
         ax2 = fig.add_subplot(gs[irow, 0])
         im = ax2.hexbin(peak_sum, peak_max, gridsize=100, mincnt=1, norm=LogNorm(), cmap='gray')
 
-        ax2.set_xlabel('sum in peak')
-        ax2.set_ylabel('max in peak')
+        ax2.set_xlabel(f'{xlabel} in peak')
+        ax2.set_ylabel(f'{ylabel} in peak')
 
         ax3 = fig.add_subplot(gs[irow, 1])
         im = ax3.hexbin(peak_sig, peak_max, gridsize=100, mincnt=1, norm=LogNorm(), cmap='gray')


### PR DESCRIPTION
Resolving the error noted in Issue #16. With this fix, an example normal peakogram looks like:
![download](https://user-images.githubusercontent.com/6363287/156092101-37bbc0e1-49f8-48e6-86c4-aa4af2d708d3.png)
As an alternative, one could plot the "Iogram" by setting `plot_Iogram=True` when calling the `plot_peakogram` function. For the above stream file, the "Iogram" looks like this:
![download-1](https://user-images.githubusercontent.com/6363287/156092279-1d9b488c-6e8f-45f1-b81f-7e7a0b1e627d.png)
Thanks @fredericpoitevin for catching that bug!
